### PR TITLE
Avoid compiler error on ESP8266 and ESP32

### DIFF
--- a/src/TFMPI2C.cpp
+++ b/src/TFMPI2C.cpp
@@ -102,7 +102,7 @@ bool TFMPI2C::getData( int16_t &dist, int16_t &flux, int16_t &temp, uint8_t addr
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Request one data-frame from the slave device address
     // and close the I2C interface.
-    Wire.requestFrom( (int)addr, TFMP_FRAME_SIZE, true);
+    Wire.requestFrom( (int)addr, TFMP_FRAME_SIZE, (int)true);
 
     memset( frame, 0, sizeof( frame));     // Clear the data-frame buffer.
     for( uint8_t i = 0; i < TFMP_FRAME_SIZE; i++)
@@ -261,7 +261,7 @@ bool TFMPI2C::sendCommand( uint32_t cmnd, uint32_t param, uint8_t addr)
 
     // Request reply data from the device and
     // close the I2C interface.
-    Wire.requestFrom( (int)addr, (int)replyLen, true);
+    Wire.requestFrom( (int)addr, (int)replyLen, (int)true);
 
     memset( reply, 0, sizeof( reply));   // Clear the reply data buffer.
     for( uint8_t i = 0; i < replyLen; i++)


### PR DESCRIPTION
TLDR : Set explicit types for calls to Wire.requestFrom, as the signature was ambiguous.

More detail:

The signatures of Wire.requestFrom that I know of are:

Specific for ESP8266 (https://github.com/esp8266/Arduino/blob/master/libraries/Wire/Wire.cpp):
* size_t TwoWire::requestFrom(uint8_t address, size_t size, bool sendStop)

Specific for ESP32 (https://github.com/espressif/arduino-esp32/blob/master/libraries/Wire/src/Wire.cpp)
* size_t TwoWire::requestFrom(uint16_t address, size_t size, bool sendStop)
* size_t TwoWire::requestFrom(uint8_t address, size_t len, bool sendStop)
* uint8_t TwoWire::requestFrom(uint16_t address, uint8_t len, uint8_t sendStop)
* uint8_t TwoWire::requestFrom(uint16_t address, uint8_t len, bool stopBit)
* uint8_t TwoWire::requestFrom(uint16_t address, uint8_t len)

Specific for ArduinoCore-avr (https://github.com/arduino/ArduinoCore-avr/blob/master/libraries/Wire/src/Wire.cpp):
* uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint32_t iaddress, uint8_t isize, uint8_t sendStop)

Common for all three:
* uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint8_t sendStop)
* uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity)
* uint8_t TwoWire::requestFrom(int address, int quantity)
* uint8_t TwoWire::requestFrom(int address, int quantity, int sendStop)

Calling with (int,int,bool), as originally present, is ambiguous for ESP8266 and ESP32, but not for ArduinoCore-avr. 
A signature that would be unambiguous is (int,int,int) or (uint8_t,uint8_t,uint8_t).
So I went for (int,int,int), as that was the closest to the original code.

Frankly, (uint8_t,size_t,bool) should be the correct one, but avr does not have that as an explicit signature.

In the issue https://github.com/budryerson/TFMini-Plus-I2C/issues/12 I proposed another mapping, but that would be wrong for ArduinoCore-avr.



Not strictly related: 1.7.2 is from 2022, not 2021. I did not correct that.